### PR TITLE
Organize JSX apps

### DIFF
--- a/jsx_apps/what_AI_model_for_what.jsx
+++ b/jsx_apps/what_AI_model_for_what.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+const { useState } = React;
 
 const AICapabilitiesDiagram = () => {
   // Define the three layers of nodes
@@ -417,4 +417,4 @@ const AICapabilitiesDiagram = () => {
   );
 };
 
-export default AICapabilitiesDiagram;
+window.AICapabilitiesDiagram = AICapabilitiesDiagram;

--- a/web_apps/what_AI_model_for_what.html
+++ b/web_apps/what_AI_model_for_what.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>AI Model Capabilities</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="p-4">
+  <div id="root"></div>
+  <script type="text/babel" src="../jsx_apps/what_AI_model_for_what.jsx"></script>
+  <script type="text/babel">
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<AICapabilitiesDiagram />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- move `what_AI_model_for_what.jsx` into a new `jsx_apps` directory
- create an HTML wrapper so it can run via React and Babel

## Testing
- `./setup.sh` *(fails: npm missing)*
- `npm test` *(fails: npm missing)*

------
https://chatgpt.com/codex/tasks/task_e_6844a21cd0648332b9d117fb30771737