### PR TITLE
Add index back links

### DIFF
--- a/web_apps/3D_Construction_Workflow.html
+++ b/web_apps/3D_Construction_Workflow.html
@@ -13,6 +13,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/dat-gui/0.7.7/dat.gui.min.js"></script>
   </head>
   <body>
+    <p><a href="../index.html">Back to Card Index</a></p>
     <h1>Dynamic Construction Workflow: Interdependencies in Construction Projects</h1>
     <script>
       // Set up scene, camera, and renderer

--- a/web_apps/Project_Decision_Framing_Tool.html
+++ b/web_apps/Project_Decision_Framing_Tool.html
@@ -18,6 +18,7 @@
     </style>
 </head>
 <body>
+<p><a href="../index.html">Back to Card Index</a></p>
 
 <h1>Project Decision Framing Tool</h1>
 <p>This tool helps you structure a recurring project decision using Warren Powell's Sequential Decision Framework (State, Decision, Exogenous Information).</p>

--- a/web_apps/hs2_WBS_to_PBS.html
+++ b/web_apps/hs2_WBS_to_PBS.html
@@ -211,6 +211,7 @@
     </style>
 </head>
 <body>
+    <p><a href="../index.html">Back to Card Index</a></p>
     <div id="sidebar">
         <h2>HS2 Overview</h2>
         <ul id="phase-selector">

--- a/web_apps/pm_gap_map.html
+++ b/web_apps/pm_gap_map.html
@@ -27,6 +27,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.9.0/d3.min.js"></script>
 </head>
 <body>
+<p><a href="../index.html">Back to Card Index</a></p>
 <header><h1>Project‑Management Gap Map</h1></header>
 <div id="controls"></div>
 <div id="list"></div>

--- a/web_apps/project-controls-knowledge-graph.html
+++ b/web_apps/project-controls-knowledge-graph.html
@@ -10,6 +10,7 @@
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="p-4">
+  <p><a href="../index.html">Back to Card Index</a></p>
   <div id="root"></div>
   <script type="text/babel" data-presets="typescript,react" src="../tsx_apps/project-controls-knowledge-graph.tsx"></script>
   <script type="text/babel">

--- a/web_apps/what_AI_model_for_what.html
+++ b/web_apps/what_AI_model_for_what.html
@@ -9,6 +9,7 @@
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="p-4">
+  <p><a href="../index.html">Back to Card Index</a></p>
   <div id="root"></div>
   <script type="text/babel" src="../jsx_apps/what_AI_model_for_what.jsx"></script>
   <script type="text/babel">


### PR DESCRIPTION
## Summary
- add a link to `index.html` at the top of each web app for easy navigation

## Testing
- `./setup.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844b2259f048332be542ca2a1cc05f3