### PR TITLE
Use global lucide and remove exports in P3M tool

### DIFF
--- a/tsx_apps/p3m-capability-tool.tsx
+++ b/tsx_apps/p3m-capability-tool.tsx
@@ -1,5 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { Plus, Trash2, Download, Upload, ChevronRight, ChevronDown, Check, X, Target, TrendingUp, BarChart3, Filter, Info, HelpCircle, BookOpen } from 'lucide-react';
+const { useState, useEffect } = React;
+const {
+  Plus, Trash2, Download, Upload, ChevronRight, ChevronDown,
+  Check, X, Target, TrendingUp, BarChart3, Filter, Info,
+  HelpCircle, BookOpen
+} = lucideReact;
 
 const P3MCapabilityTool = () => {
   // Parse the initial data into hierarchical structure with typical maturity levels
@@ -1252,5 +1256,3 @@ const P3MCapabilityTool = () => {
     </div>
   );
 };
-
-export default P3MCapabilityTool;

--- a/web_apps/p3m-capability-tool.html
+++ b/web_apps/p3m-capability-tool.html
@@ -6,6 +6,7 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/lucide-react/dist/lucide-react.min.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="p-4">


### PR DESCRIPTION
## Summary
- adapt `p3m-capability-tool.tsx` for in-browser Babel compilation
- inject `lucide-react` UMD build in HTML

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846e12af8f083329169b2694ab94f21