### PR TITLE
Fix P3M tool rendering

### DIFF
--- a/tsx_apps/p3m-capability-tool.tsx
+++ b/tsx_apps/p3m-capability-tool.tsx
@@ -1,9 +1,29 @@
 const { useState, useEffect } = React;
-const {
-  Plus, Trash2, Download, Upload, ChevronRight, ChevronDown,
-  Check, X, Target, TrendingUp, BarChart3, Filter, Info,
-  HelpCircle, BookOpen
-} = lucideReact;
+
+// Minimal icon placeholders so the tool can run without external
+// dependencies like `lucide-react`. Each icon simply renders a
+// character wrapped in a span so Tailwind sizing classes continue to
+// work when the TSX is compiled in the browser.
+const createIcon = (symbol: string) =>
+  ({ className = '', ...props }) => (
+    <span className={`inline-block ${className}`} {...props}>{symbol}</span>
+  );
+
+const Plus = createIcon('+');
+const Trash2 = createIcon('🗑');
+const Download = createIcon('⬇');
+const Upload = createIcon('⬆');
+const ChevronRight = createIcon('▶');
+const ChevronDown = createIcon('▼');
+const Check = createIcon('✔');
+const X = createIcon('✕');
+const Target = createIcon('🎯');
+const TrendingUp = createIcon('📈');
+const BarChart3 = createIcon('📊');
+const Filter = createIcon('🔍');
+const Info = createIcon('ℹ');
+const HelpCircle = createIcon('❓');
+const BookOpen = createIcon('📖');
 
 const P3MCapabilityTool = () => {
   // Parse the initial data into hierarchical structure with typical maturity levels

--- a/web_apps/p3m-capability-tool.html
+++ b/web_apps/p3m-capability-tool.html
@@ -6,7 +6,6 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/lucide-react/dist/lucide-react.min.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="p-4">


### PR DESCRIPTION
## Summary
- remove lucide-react dependency from p3m HTML page
- inline minimal placeholder icons in `p3m-capability-tool.tsx`

## Testing
- `node test.js` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e8f3f3ec833293a2f25f6a320367