### PR TITLE
Add Project Dynamics Simulator wrapper

### DIFF
--- a/tsx_apps/project-dynamics-simulator.tsx
+++ b/tsx_apps/project-dynamics-simulator.tsx
@@ -1,6 +1,29 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, LineChart, Line, CartesianGrid, ResponsiveContainer } from 'recharts';
-import { AlertCircle, Clock, Target, ThumbsUp, AlertTriangle, Zap } from 'lucide-react';
+const { useState, useEffect, useRef } = React;
+const {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  LineChart,
+  Line,
+  CartesianGrid,
+  ResponsiveContainer,
+} = Recharts;
+
+const createIcon = (symbol: string) =>
+  ({ className = "", ...props }) => (
+    <span className={`inline-block ${className}`} {...props}>{symbol}</span>
+  );
+
+const AlertCircle = createIcon("⚠");
+const Clock = createIcon("⏰");
+const Target = createIcon("🎯");
+const ThumbsUp = createIcon("👍");
+const AlertTriangle = createIcon("⚠");
+const Zap = createIcon("⚡");
+
 
 const ProjectDynamicsSimulator = () => {
   // State for simulation parameters

--- a/web_apps/project-dynamics-simulator.html
+++ b/web_apps/project-dynamics-simulator.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Project Dynamics Simulator</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="p-4">
+  <p><a href="../index.html">Back to Card Index</a></p>
+  <div id="root"></div>
+  <script type="text/babel" data-presets="typescript,react" src="../tsx_apps/project-dynamics-simulator.tsx"></script>
+  <script type="text/babel">
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<ProjectDynamicsSimulator />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make project-dynamics-simulator.tsx browser-friendly by removing module imports
- add placeholder icons and reference Recharts global
- create a new HTML wrapper that loads the TSX via Babel

## Testing
- `./setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848546b43388332ae775af367374f89