### PR TITLE
Fix hs2 contract game rendering

### DIFF
--- a/tsx_apps/hs2-contract-game.tsx
+++ b/tsx_apps/hs2-contract-game.tsx
@@ -268,4 +268,3 @@ const GameTheorySimulator = () => {
   );
 };
 
-export default GameTheorySimulator;


### PR DESCRIPTION
## Summary
- remove `export default` from GameTheorySimulator so it registers globally

## Testing
- `./setup.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684854bddc2483329af5ce3172e8599a