### PR TITLE
Add interactive concept map HTML wrapper

### DIFF
--- a/web_apps/interactive-concept-map.html
+++ b/web_apps/interactive-concept-map.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Interactive Concept Map</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="p-4">
+  <p><a href="../index.html">Back to Card Index</a></p>
+  <div id="root"></div>
+  <script type="text/babel" data-presets="typescript,react" src="../tsx_apps/interactive-concept-map.tsx"></script>
+  <script type="text/babel">
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<InteractiveConceptMap />);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an HTML page that loads `interactive-concept-map.tsx` using Babel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485cc3ccc08332b17717bfac774c05