### PR TITLE
Fix dynamic simulator and concept map rendering

### DIFF
--- a/tsx_apps/interactive-concept-map.tsx
+++ b/tsx_apps/interactive-concept-map.tsx
@@ -1,4 +1,7 @@
-import React, { useState, useCallback } from 'react';
+// This file runs directly in the browser via Babel so we can't rely on ES module
+// imports. Instead we use the globally provided `React` variable from the HTML
+// wrapper.
+const { useState, useCallback } = React;
 
 const TriadGraph = ({ triad }) => {
   const centerX = 150;
@@ -166,4 +169,3 @@ const InteractiveConceptMap = () => {
   );
 };
 
-export default InteractiveConceptMap;

--- a/tsx_apps/project-dynamics-simulator.tsx
+++ b/tsx_apps/project-dynamics-simulator.tsx
@@ -572,8 +572,3 @@ const ProjectDynamicsSimulator = () => {
   );
 };
 
-// Bootstrap the React component once the DOM is ready
-document.addEventListener('DOMContentLoaded', () => {
-  const root = ReactDOM.createRoot(document.getElementById('root'));
-  root.render(<ProjectDynamicsSimulator />);
-});

--- a/web_apps/project-dynamics-simulator.html
+++ b/web_apps/project-dynamics-simulator.html
@@ -13,5 +13,9 @@
   <p><a href="../index.html">Back to Card Index</a></p>
   <div id="root"></div>
   <script type="text/babel" data-presets="typescript,react" src="../tsx_apps/project-dynamics-simulator.tsx"></script>
+  <script type="text/babel">
+    const root = ReactDOM.createRoot(document.getElementById('root'));
+    root.render(<ProjectDynamicsSimulator />);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove module syntax from interactive concept map so it runs in browser
- bootstrap project dynamics simulator from HTML instead of TSX

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485f82afb88332b401a29d6dc3b09a