### PR TITLE
Fix load order in project dynamics simulator

### DIFF
--- a/web_apps/project-dynamics-simulator.html
+++ b/web_apps/project-dynamics-simulator.html
@@ -4,17 +4,19 @@
   <meta charset="UTF-8">
   <title>Project Dynamics Simulator</title>
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
-  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
-  <script src="project-dynamics-simulator.js"></script>
+  <script crossorigin defer src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin defer src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script defer src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+  <script defer src="project-dynamics-simulator.js"></script>
 </head>
 <body class="p-4">
   <p><a href="../index.html">Back to Card Index</a></p>
   <div id="root"></div>
   <script>
-    const root = ReactDOM.createRoot(document.getElementById('root'));
-    root.render(React.createElement(ProjectDynamicsSimulator));
+    document.addEventListener('DOMContentLoaded', () => {
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(React.createElement(ProjectDynamicsSimulator));
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- defer all scripts in Project Dynamics Simulator so they load after the DOM
- initialise React component on DOMContentLoaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68486d4f60f083329b86c7f09b25278b