### PR TITLE
Fix Recharts loading in simulator

### DIFF
--- a/web_apps/project-dynamics-simulator.html
+++ b/web_apps/project-dynamics-simulator.html
@@ -6,8 +6,8 @@
   <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="p-4">
   <p><a href="../index.html">Back to Card Index</a></p>


### PR DESCRIPTION
## Summary
- reorder script tags in `project-dynamics-simulator.html` so Recharts loads before Babel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68488d470c808332986e79ce915bf7f7