### PR TITLE
Add project management simulation html

### DIFF
--- a/tsx_apps/project-management-simulation.tsx
+++ b/tsx_apps/project-management-simulation.tsx
@@ -1,9 +1,72 @@
-import React, { useState, useEffect } from 'react';
-import { LineChart, Line, BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer, ErrorBar, ReferenceLine } from 'recharts';
-import { Button } from '@/components/ui/button';
-import { Card, CardHeader, CardContent, CardFooter } from '@/components/ui/card';
-import { Slider } from '@/components/ui/slider';
-import { AlertCircle, Info, ArrowRight, Activity, BarChart2, Clock } from 'lucide-react';
+// This file is executed directly in the browser using Babel. We therefore rely
+// on the globally provided `React` and `Recharts` variables rather than ES
+// module imports. Minimal stand-ins for the UI components from `shadcn/ui` and
+// the `lucide-react` icons are implemented below so the simulation can run
+// without additional build steps or dependencies.
+
+const { useState, useEffect } = React;
+const {
+  LineChart,
+  Line,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ErrorBar,
+  ReferenceLine,
+} = Recharts;
+
+const Card = ({ className = '', ...props }) => (
+  <div className={`border rounded shadow p-4 ${className}`} {...props} />
+);
+const CardHeader = ({ className = '', ...props }) => (
+  <div className={`mb-4 ${className}`} {...props} />
+);
+const CardContent = ({ className = '', ...props }) => (
+  <div className={`mb-4 ${className}`} {...props} />
+);
+const CardFooter = ({ className = '', ...props }) => (
+  <div className={`mt-4 ${className}`} {...props} />
+);
+
+const Button = ({ className = '', variant, ...props }) => (
+  <button
+    className={`px-4 py-2 rounded ${
+      variant === 'outline'
+        ? 'border'
+        : variant === 'destructive'
+        ? 'bg-red-500 text-white'
+        : 'bg-blue-500 text-white'
+    } ${className}`}
+    {...props}
+  />
+);
+
+const Slider = ({ value, onValueChange, max = 100, step = 1 }) => (
+  <input
+    type="range"
+    value={value[0]}
+    onChange={(e) => onValueChange([Number(e.target.value)])}
+    max={max}
+    step={step}
+    className="w-full"
+  />
+);
+
+const createIcon = (symbol: string) =>
+  ({ className = '', ...props }) => (
+    <span className={`inline-block ${className}`} {...props}>{symbol}</span>
+  );
+
+const AlertCircle = createIcon('!');
+const Info = createIcon('ℹ');
+const ArrowRight = createIcon('→');
+const Activity = createIcon('🏃');
+const BarChart2 = createIcon('📊');
+const Clock = createIcon('⏱');
 
 const initialState = {
   step: 0,
@@ -390,4 +453,3 @@ const ProjectManagementSimulation = () => {
   );
 };
 
-export default ProjectManagementSimulation;

--- a/web_apps/project-management-simulation.html
+++ b/web_apps/project-management-simulation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Project Management Simulation</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="p-4">
+  <p><a href="../index.html">Back to Card Index</a></p>
+  <div id="root"></div>
+  <script type="text/babel" data-presets="typescript,react" src="../tsx_apps/project-management-simulation.tsx"></script>
+  <script type="text/babel">
+    document.addEventListener('DOMContentLoaded', () => {
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(<ProjectManagementSimulation />);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- adapt `project-management-simulation.tsx` for direct browser use by removing imports and adding minimal UI/icon implementations
- add corresponding HTML wrapper to load the simulation with Babel

## Testing
- `./setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684890c35a548332ba095881e0bd2d0a