### PR TITLE
Fix Recharts load order for simulator

### DIFF
--- a/web_apps/project-management-simulation.html
+++ b/web_apps/project-management-simulation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Project Management Simulation</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body class="p-4">
+  <p><a href="../index.html">Back to Card Index</a></p>
+  <div id="root"></div>
+  <script type="text/babel" data-presets="typescript,react" src="../tsx_apps/project-management-simulation.tsx"></script>
+  <script type="text/babel">
+    document.addEventListener('DOMContentLoaded', () => {
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(<ProjectManagementSimulation />);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add missing Project Management Simulation page
- ensure Recharts script loads before Babel to avoid runtime error

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684894b137808332a8b9dd246af87462