### PR TITLE
Fix dynamics simulator dependencies

### DIFF
--- a/web_apps/project-dynamics-simulator.html
+++ b/web_apps/project-dynamics-simulator.html
@@ -3,11 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <title>Project Dynamics Simulator</title>
-  <link href="../vendor/tailwind.min.css" rel="stylesheet">
-  <script crossorigin src="../vendor/react.development.js"></script>
-  <script crossorigin src="../vendor/react-dom.development.js"></script>
-  <script src="../vendor/Recharts.min.js"></script>
-  <script src="../vendor/babel.min.js"></script>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/recharts/umd/Recharts.min.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
 <body class="p-4">
   <p><a href="../index.html">Back to Card Index</a></p>


### PR DESCRIPTION
## Summary
- fix `project-dynamics-simulator.html` by loading external CDN links for React, ReactDOM, Recharts, Babel and Tailwind

## Testing
- `bash setup.sh`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b234c4d08833298e1ece22e4e47ff