### PR TITLE
Add missing index links and handle 22.png

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,14 @@ function createCards(data){
         const img=document.createElement('img');
         img.src='pics/'+item['#']+'.PNG';
         img.alt=item.name;
-        img.onerror=()=>{img.src='pics/blank.png';};
+        img.onerror=()=>{
+            if(!img.dataset.fallback){
+                img.dataset.fallback='lower';
+                img.src='pics/'+item['#']+'.png';
+            } else {
+                img.src='pics/blank.png';
+            }
+        };
         card.appendChild(img);
         const title=document.createElement('h3');
         const link=document.createElement('a');

--- a/web_apps/AI_timeline_from_Gemini_25.html
+++ b/web_apps/AI_timeline_from_Gemini_25.html
@@ -51,6 +51,7 @@
     </style>
 </head>
 <body class="bg-gray-100 text-gray-800">
+    <p><a href="../index.html">Back to Card Index</a></p>
 
     <div class="container mx-auto p-4 md:p-8">
         <header class="text-center mb-8">

--- a/web_apps/consulting_catalogue.html
+++ b/web_apps/consulting_catalogue.html
@@ -30,6 +30,7 @@
 </style>
 </head>
 <body>
+<p><a href="../index.html">Back to Card Index</a></p>
 <header>
     <h1>Project‑Director Consulting Catalogue</h1>
     <nav>


### PR DESCRIPTION
## Summary
- ensure 22.png shows up by trying `.png` if `.PNG` fails
- add "Back to Card Index" link to AI timeline app
- add "Back to Card Index" link to consulting catalogue app

## Testing
- `bash setup.sh`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b3c2a1bec8332b557a3f4b0ce8a2b