### PR TITLE
Add Governance Trio replay/rules/lineage web app

### DIFF
--- a/app-index.csv
+++ b/app-index.csv
@@ -86,3 +86,4 @@
 74,regulatory-negotiation-rehearsal-board,"Guided regulatory negotiation rehearsal board with deal posture, levers, Shapley pivotality, constraint heatmap, synergies, clause library, and audit receipts.",User,GPT-5.2-Codex,"regulatory, negotiation, contracts, simulation, decision_support, visualization",,
 
 75,contract-portfolio-board,"Interactive contract portfolio board for allocating items into contracts, workstreams, context, and internal scope.",User,GPT-5.3-Codex,"contracts, portfolio_management, planning, visualization, interactive",,
+76,governance-trio-replay-rules-lineage,"Governance Trio live demo linking deterministic replay proof, machine-checkable rule receipts, and lineage DAG provenance.",User,GPT-5.3-Codex,"governance, assurance, lineage, replay, controls, visualization",,

--- a/web_apps/governance-trio-replay-rules-lineage.html
+++ b/web_apps/governance-trio-replay-rules-lineage.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Governance Trio: Replay • Rules • Lineage (Live Demo)</title>
+<style>
+  :root{
+    --bg:#0e1116; --panel:#161a22; --ink:#e8eefc; --muted:#9fb3d9; --ok:#2bb673; --bad:#ff6b6b; --warn:#f2b84b; --wire:#2a3040; --accent:#6aa3ff;
+  }
+  *{box-sizing:border-box} body{margin:0;font:14px/1.35 system-ui,Segoe UI,Roboto,Helvetica,Arial;background:var(--bg);color:var(--ink)}
+  header{padding:16px 20px;border-bottom:1px solid #1f2533;background:linear-gradient(180deg,#121622,#0e1116)}
+  .titlebar{display:flex;align-items:center;gap:10px;justify-content:space-between}
+  header h1{margin:0;font-size:18px}
+  header p{margin:6px 0 0;color:var(--muted)}
+  main{display:grid;gap:14px;padding:16px 16px 112px;grid-template-columns:minmax(290px,330px) minmax(0,1fr);max-width:1180px;margin:0 auto}
+  .card{background:var(--panel);border:1px solid #1f2533;border-radius:8px;box-shadow:0 12px 24px rgba(0,0,0,.25)}
+  .cardTitle{padding:12px 14px;border-bottom:1px solid #1f2533;display:flex;align-items:center;justify-content:space-between;gap:10px}
+  .cardTitle h2{margin:0;font-size:14px;color:#cfe0ff;letter-spacing:.2px}
+  .left{display:flex;flex-direction:column;gap:14px}
+  .flow{padding:14px}
+  .flow .step{display:grid;grid-template-columns:auto minmax(0,1fr) auto;align-items:center;gap:10px;padding:8px;border:1px dashed #2a3144;border-radius:8px;margin-bottom:10px}
+  .flow .step input{transform:scale(1.1)}
+  .flow label{min-width:0;overflow-wrap:anywhere}
+  .flow .meta{margin-left:auto;color:var(--muted);font-size:12px;text-align:right;white-space:nowrap}
+  .badge{display:inline-block;padding:2px 8px;border-radius:999px;background:#22304d;color:#cfe0ff;font-size:12px;border:1px solid #2a3a5e}
+  .grid{display:grid;gap:14px;grid-template-columns:1fr;align-content:start}
+  .pane{padding:12px 12px 6px}
+  .pane h3{margin:0 0 8px;font-size:13px;color:#cfe0ff}
+  .log{background:#0b0e14;border:1px solid #192034;border-radius:8px;padding:10px;max-height:220px;overflow:auto}
+  .log code{white-space:pre-wrap;color:#cfe0ff}
+  .rules table{width:100%;border-collapse:collapse;font-size:13px}
+  .rules th,.rules td{padding:8px;border-bottom:1px solid #1f2533}
+  .rules tr:last-child td{border-bottom:none}
+  .pass{color:var(--ok);font-weight:600}
+  .fail{color:var(--bad);font-weight:600}
+  .legend{display:flex;gap:8px;align-items:center;color:var(--muted);font-size:12px;margin-top:6px}
+  .dot{width:10px;height:10px;border-radius:50%}
+  .canvasWrap{position:relative;padding:10px;border:1px solid #1f2533;border-radius:8px;background:#0b0e14;overflow:auto}
+  #graph{width:100%;min-width:760px;height:260px;display:block;background:
+    linear-gradient(90deg,transparent 49%, #151b29 50%, transparent 51%) 0 0/60px 60px,
+    linear-gradient(0deg,transparent 49%, #151b29 50%, transparent 51%) 0 0/60px 60px}
+  .pill{position:absolute;top:10px;right:10px}
+  .footer{position:fixed;inset:auto 0 0 0;background:#0b0e14;border-top:1px solid #1f2533;padding:10px 16px;color:var(--muted);display:flex;justify-content:space-between;align-items:center;gap:12px}
+  .footer div:first-child{min-width:0}
+  .actions{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+  button{background:#1c2b4d;color:#e6efff;border:1px solid #2b4279;border-radius:8px;padding:8px 10px;cursor:pointer}
+  .iconBtn{display:inline-grid;place-items:center;width:28px;height:28px;min-width:28px;padding:0;border-radius:50%;font-weight:700;line-height:1;background:#17233d;border-color:#2b4279;color:#dbe7ff}
+  .iconBtn:hover,.mini:hover{border-color:#4d76ce;background:#223965}
+  button:disabled{opacity:.6;cursor:not-allowed}
+  .mini{font-size:12px;padding:6px 8px;border-radius:999px}
+  .tight{letter-spacing:.2px}
+  .kbd{font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;background:#0b0e14;border:1px solid #273249;color:#cfe0ff;padding:2px 6px;border-radius:6px}
+  [hidden]{display:none!important}
+  .modalOverlay{position:fixed;inset:0;z-index:20;background:rgba(5,8,13,.72);display:grid;place-items:center;padding:18px}
+  .modal{position:relative;width:min(620px,100%);max-height:min(720px,calc(100vh - 36px));overflow:auto;background:#151b27;border:1px solid #2a3650;border-radius:8px;box-shadow:0 28px 80px rgba(0,0,0,.5);padding:20px}
+  .modal .close{position:absolute;top:12px;right:12px}
+  .modal .eyebrow{margin:0 38px 6px 0;color:var(--muted);font-size:12px;text-transform:uppercase;letter-spacing:.08em}
+  .modal h2{margin:0 38px 12px 0;font-size:18px;color:#e8eefc}
+  .modalBody{color:#c9d7f2}
+  .modalBody p{margin:0 0 10px}
+  .modalBody ul,.modalBody ol{margin:8px 0 0 20px;padding:0}
+  .modalBody li{margin:6px 0}
+  .modalBody strong{color:#eef4ff}
+  @media (max-width: 820px){
+    header{padding:14px 16px}
+    main{grid-template-columns:1fr;padding:14px 14px 16px}
+    .flow .step{grid-template-columns:auto minmax(0,1fr)}
+    .flow .meta{grid-column:2;margin-left:0;text-align:left;white-space:normal}
+    .footer{position:static;align-items:flex-start;flex-direction:column}
+    .actions{justify-content:flex-start}
+  }
+</style>
+</head>
+<body>
+  <header>
+    <div class="titlebar">
+      <h1>Governance Trio — live update</h1>
+      <button class="iconBtn" type="button" data-help="overview" aria-label="What is this and how do I use it?" title="What is this?">?</button>
+    </div>
+    <p>Toggle events on the left; the right‑hand artefacts update immediately: <span class="kbd">Replay Proof</span>, <span class="kbd">Rule Receipts</span>, and a <span class="kbd">Lineage Map</span>.</p>
+  </header>
+
+  <main>
+    <section class="left">
+      <div class="card">
+        <div class="cardTitle"><h2>Scenario: Workflow Events</h2><button class="iconBtn" type="button" data-help="scenario" aria-label="About workflow events" title="About this panel">?</button></div>
+        <div class="flow" id="flow"></div>
+      </div>
+
+      <div class="card">
+        <div class="cardTitle"><h2>Rulebook (human‑readable)</h2><button class="iconBtn" type="button" data-help="rulebook" aria-label="About the rulebook" title="About this panel">?</button></div>
+        <div class="pane">
+          <p class="legend">
+            <span class="dot" style="background:var(--ok)"></span> pass
+            <span class="dot" style="background:var(--bad)"></span> fail
+            <span class="badge">v0.1 demo</span>
+          </p>
+          <ul>
+            <li><strong>R1 — Two‑person review:</strong> Any document marked <em>approved</em> must have ≥ 2 reviewers.</li>
+            <li><strong>R2 — Traceable output:</strong> Every deliverable must cite ≥ 1 input artefact.</li>
+            <li><strong>R3 — Timing guard:</strong> Approval cannot precede build completion.</li>
+            <li><strong>R4 — Authority scope:</strong> Only roles {Lead, QA} may approve.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid">
+      <div class="card">
+        <div class="cardTitle"><h2>Replay Proof (deterministic log)</h2><button class="iconBtn" type="button" data-help="replay" aria-label="About the replay proof" title="About this panel">?</button></div>
+        <div class="pane">
+          <div class="log"><code id="replay"></code></div>
+          <div class="legend"><span class="badge">Deterministic seed:</span> <span id="seed" class="kbd">—</span></div>
+        </div>
+      </div>
+
+      <div class="card rules">
+        <div class="cardTitle"><h2>Rule Receipts (machine‑checkable)</h2><button class="iconBtn" type="button" data-help="receipts" aria-label="About rule receipts" title="About this panel">?</button></div>
+        <div class="pane">
+          <table id="rules">
+            <thead><tr><th style="text-align:left;">Rule</th><th>Status</th><th style="text-align:left;">Explanation</th></tr></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="cardTitle"><h2>Lineage Map (who/what produced what)</h2><button class="iconBtn" type="button" data-help="lineage" aria-label="About the lineage map" title="About this panel">?</button></div>
+        <div class="pane">
+          <div class="canvasWrap">
+            <canvas id="graph"></canvas>
+            <span class="pill badge">DAG of artefacts</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div class="footer">
+    <div>Tip: click <span class="kbd">Reset</span> to see how receipts & lineage snap back. All logic runs in‑browser.</div>
+    <div class="actions">
+      <button class="mini tight" type="button" data-help="using">Help</button>
+      <button id="seedBtn" class="mini tight">New Seed</button>
+      <button id="resetBtn" class="mini tight">Reset</button>
+      <button id="shareBtn" class="mini tight">Share State</button>
+    </div>
+  </div>
+
+  <div class="modalOverlay" id="helpOverlay" hidden>
+    <section class="modal" role="dialog" aria-modal="true" aria-labelledby="helpTitle" aria-describedby="helpBody">
+      <button class="iconBtn close" id="helpClose" type="button" aria-label="Close help" title="Close">x</button>
+      <p class="eyebrow" id="helpKicker"></p>
+      <h2 id="helpTitle"></h2>
+      <div class="modalBody" id="helpBody"></div>
+    </section>
+  </div>
+
+<script>
+const Steps = [
+  { id:"ingest",  label:"Data Ingested",          meta:"source: s3://bucket" },
+  { id:"build",   label:"Model Built",            meta:"duration: 37m"       },
+  { id:"review1", label:"Review by Alice (QA)",   meta:"role: QA"            },
+  { id:"review2", label:"Review by Bob (Dev)",    meta:"role: Dev"           },
+  { id:"approve", label:"Approved by Carol (Lead)",meta:"role: Lead"         },
+  { id:"publish", label:"Deliverable Published",  meta:"target: /reports/v1" }
+];
+let active = new Set();
+let reviewers = new Set();
+let approvers = new Set();
+let edges = [];
+let seed = Math.floor(Math.random()*1e9);
+let lastHelpTrigger = null;
+const HelpTopics = { overview:{kicker:"Guide",title:"What is this?",body:`<p>This is a small governance assurance demo. It shows how ordinary workflow events can generate three linked artefacts: a replay log, rule receipts, and a lineage map.</p><p>The useful idea is that the evidence updates as the scenario changes. You can try a clean process, or deliberately create a broken one and watch the receipts explain what failed.</p><ol><li>Tick workflow events in the scenario panel.</li><li>Read the receipts to see which controls pass or fail.</li><li>Use the lineage map to check whether the published output has a credible chain of evidence.</li></ol>`}, using:{kicker:"Quick start",title:"How to use it",body:`<ol><li>Start with <strong>Data Ingested</strong> and <strong>Model Built</strong>.</li><li>Add two review steps, then approval, then publication.</li><li>Try bad cases too: approval without build, publication without build, or approval with only one reviewer.</li><li>Use <strong>Share State</strong> to copy a link that preserves the current scenario and seed.</li></ol><p><strong>New Seed</strong> changes the deterministic run identity and timestamps. <strong>Reset</strong> clears the scenario.</p>`}, scenario:{kicker:"Input",title:"Workflow events",body:`<p>These checkboxes are the scenario. They stand in for events that might come from a real workflow system: ingest, build, review, approve, and publish.</p><p>The app does not force a valid order. That is intentional: invalid combinations are how you test whether the governance controls catch problems.</p>`}, rulebook:{kicker:"Controls",title:"Human-readable rulebook",body:`<p>The rulebook is the plain-English version of the controls. It says what good governance should require before a deliverable is considered trustworthy.</p><ul><li><strong>R1</strong> checks independent review count.</li><li><strong>R2</strong> checks traceability from published output to an input artefact.</li><li><strong>R3</strong> checks approval timing.</li><li><strong>R4</strong> checks approval authority.</li></ul>`}, replay:{kicker:"Evidence",title:"Replay proof",body:`<p>The replay proof is a deterministic event log for the selected scenario. With the same selected events and seed, it produces the same run id and timestamps after reload.</p><p>In a real system, this would help someone reproduce what happened rather than relying on a manually written status note.</p>`}, receipts:{kicker:"Evidence",title:"Rule receipts",body:`<p>Receipts are the machine-checkable verdicts. Each row shows the rule, pass/fail status, and the reason for that verdict.</p><p>This is the strongest part of the demo: failures explain themselves, so the user can see exactly what evidence is missing.</p>`}, lineage:{kicker:"Evidence",title:"Lineage map",body:`<p>The lineage map shows which artefacts produced which later artefacts. It is a simple provenance graph.</p><p>If publication happens without a build, the map does not draw a model-to-deliverable edge. That keeps the visual evidence aligned with the rule receipts.</p>`}};
+function deterministicHash(s){let h=2166136261>>>0;for(let i=0;i<s.length;i++){h^=s.charCodeAt(i);h=Math.imul(h,16777619)>>>0}return h>>>0;}
+function setSeed(n){ seed=n; document.getElementById('seed').textContent = String(seed); }
+function createPrng(n){ let x = (n || 1) >>> 0; return function(){ x ^= x<<13; x ^= x>>>17; x ^= x<<5; x >>>= 0; return x/0xFFFFFFFF; }; }
+function selectedIds(){ return Steps.filter(s=>active.has(s.id)).map(s=>s.id); }
+function selectedSteps(){ return Steps.filter(s=>active.has(s.id)); }
+function renderSteps(){ const box = document.getElementById('flow'); box.innerHTML=''; Steps.forEach(s=>{ const row=document.createElement('div'); row.className='step'; const cb=document.createElement('input'); cb.type='checkbox'; cb.id='cb_'+s.id; cb.checked=active.has(s.id); cb.addEventListener('change',()=>{ if(cb.checked) activate(s.id); else deactivate(s.id); updateAll(); }); const lab=document.createElement('label'); lab.setAttribute('for',cb.id); lab.textContent=s.label; const meta=document.createElement('span'); meta.className='meta'; meta.textContent=s.meta; row.append(cb,lab,meta); box.appendChild(row); }); }
+function activate(id){ active.add(id); recomputeDerivedState(); }
+function deactivate(id){ active.delete(id); recomputeDerivedState(); }
+function recomputeDerivedState(){ reviewers = new Set(); approvers = new Set(); edges = []; if(active.has("review1")) reviewers.add("Alice(QA)"); if(active.has("review2")) reviewers.add("Bob(Dev)"); if(active.has("approve")) approvers.add("Carol(Lead)"); if(active.has("ingest")) edges.push(["RawData","CleanData","ingest"]); if(active.has("build")) edges.push(["CleanData","Model","build"]); if(active.has("review1")) edges.push(["Model","ReviewNote#1","review"]); if(active.has("review2")) edges.push(["Model","ReviewNote#2","review"]); if(active.has("approve")) edges.push(["{ReviewNotes}","Approval","approve"]); if(active.has("publish") && active.has("build")) edges.push(["Model","Deliverable","publish"]); }
+function renderReplay(){ const log = []; const ordered = selectedSteps(); const runId = deterministicHash(JSON.stringify({events:selectedIds(), seed})).toString(16).padStart(8,'0'); const random = createPrng(seed); const baseTime = Date.UTC(2026,0,1,9,0,0) + (seed % (7*24*60))*60000; let elapsedSeconds = 0; log.push(`run_id: ${runId}`); ordered.forEach((s,i)=>{ elapsedSeconds += i===0 ? 0 : 300 + Math.floor(random()*120); const t = new Date(baseTime + elapsedSeconds*1000).toISOString(); log.push(`${i+1}. ${t} :: ${s.id} :: ${s.label}`); }); if(!ordered.length) log.push("(no events selected)"); document.getElementById('replay').textContent = log.join("\n"); }
+function evaluateRules(){ const have = (id)=>active.has(id); const out = []; if(have("approve")){ const ok = reviewers.size>=2; out.push({rule:"R1 Two‑person review", ok, why: ok?`reviewers=${[...reviewers].join(", ")}`:`only ${reviewers.size} reviewer(s); approver is not counted`}); } else { out.push({rule:"R1 Two‑person review", ok:true, why:"n/a (no approval yet)"}); } if(have("publish")){ const ok = have("build"); out.push({rule:"R2 Traceable output", ok, why: ok?"Deliverable cites Model":"Deliverable has no upstream Model"}); } else { out.push({rule:"R2 Traceable output", ok:true, why:"n/a (not published)"}); } const r3 = !active.has("approve") || active.has("build"); out.push({rule:"R3 Timing guard", ok:r3, why: !active.has("approve")?"n/a (no approval yet)":r3?"build present before/with approve":"approved without build"}); const r4 = !active.has("approve") || [...approvers].some(a=>a.endsWith("(Lead)") || a.endsWith("(QA)")); out.push({rule:"R4 Authority scope", ok:r4, why: !active.has("approve")?"n/a (no approval yet)":r4?`approver=${[...approvers].join(", ")}`:"approval lacks authorized approver"}); return out; }
+function renderRules(){ const tbody = document.querySelector('#rules tbody'); tbody.innerHTML=''; evaluateRules().forEach(r=>{ const tr=document.createElement('tr'); const td1=document.createElement('td'); td1.textContent=r.rule; const td2=document.createElement('td'); td2.innerHTML = r.ok? `<span class="pass">PASS</span>` : `<span class="fail">FAIL</span>`; const td3=document.createElement('td'); td3.textContent=r.why; tr.append(td1,td2,td3); tbody.appendChild(tr); }); }
+function renderGraph(){ const cvs = document.getElementById('graph'), ctx=cvs.getContext('2d'); const w = cvs.clientWidth, h = cvs.clientHeight; cvs.width = w * devicePixelRatio; cvs.height = h * devicePixelRatio; ctx.scale(devicePixelRatio, devicePixelRatio); const nodes = [{id:"RawData", x:70, y:210},{id:"CleanData", x:200,y:210},{id:"Model", x:330,y:150},{id:"ReviewNote#1", x:460,y:90},{id:"ReviewNote#2", x:460,y:150},{id:"{ReviewNotes}", x:590,y:120},{id:"Approval", x:720,y:120},{id:"Deliverable", x:720,y:210}]; const pos = Object.fromEntries(nodes.map(n=>[n.id,n])); ctx.fillStyle = "#0b0e14"; ctx.fillRect(0,0,w,h); ctx.lineWidth=1.5; ctx.strokeStyle="#2d3b56"; edges.forEach(([a,b,label])=>{ if(!pos[a] || !pos[b]) return; const A=pos[a], B=pos[b]; ctx.beginPath(); ctx.moveTo(A.x, A.y); ctx.lineTo(B.x, B.y); ctx.stroke(); const ang=Math.atan2(B.y-A.y,B.x-A.x); const ax=B.x - 8*Math.cos(ang-0.5), ay=B.y - 8*Math.sin(ang-0.5); const bx=B.x - 8*Math.cos(ang+0.5), by=B.y - 8*Math.sin(ang+0.5); ctx.beginPath(); ctx.moveTo(B.x, B.y); ctx.lineTo(ax, ay); ctx.lineTo(bx, by); ctx.closePath(); ctx.fillStyle="#2d3b56"; ctx.fill(); ctx.fillStyle="#8aa7e6"; ctx.font="12px system-ui"; const mx=(A.x+B.x)/2, my=(A.y+B.y)/2; ctx.fillText(label, mx+6, my-6); }); nodes.forEach(n=>{ const on = edges.some(e=>e[0]===n.id || e[1]===n.id); ctx.fillStyle = on ? "#263a66" : "#1a2235"; ctx.strokeStyle = on ? "#6aa3ff" : "#273249"; roundedRect(ctx, n.x-48, n.y-16, 96, 32, 8, true, true); ctx.fillStyle = on ? "#dbe7ff" : "#b7c6e8"; ctx.font="12px system-ui"; ctx.textAlign="center"; ctx.textBaseline="middle"; ctx.fillText(n.id, n.x, n.y); }); function roundedRect(ctx,x,y,w,h,r,fill,stroke){ ctx.beginPath(); ctx.moveTo(x+r,y); ctx.arcTo(x+w,y,x+w,y+h,r); ctx.arcTo(x+w,y+h,x,y+h,r); ctx.arcTo(x,y+h,x,y,r); ctx.arcTo(x,y,x+w,y,r); if(fill) ctx.fill(); if(stroke) ctx.stroke(); }}
+function updateAll(){ renderReplay(); renderRules(); renderGraph(); persistURL(); }
+function resetAll(){ active.clear(); recomputeDerivedState(); setSeed(Math.floor(Math.random()*1e9)); renderSteps(); updateAll(); }
+function persistURL(){ const payload = btoa(JSON.stringify({a:selectedIds(), seed})); history.replaceState(null,"", location.pathname + "#"+payload); }
+function restoreFromURL(){ try{ if(location.hash.length>1){ const {a,seed:sd} = JSON.parse(atob(location.hash.slice(1))); const allowed = new Set(Steps.map(s=>s.id)); active = new Set((a||[]).filter(id=>allowed.has(id))); if(Number.isFinite(sd)) setSeed(sd); recomputeDerivedState(); } }catch{} }
+function setShareButton(text){ const btn=document.getElementById('shareBtn'); const old=btn.textContent; btn.textContent=text; setTimeout(()=>btn.textContent=old,1200); }
+function copyShareLink(){ const href = location.href; if(navigator.clipboard && navigator.clipboard.writeText){ navigator.clipboard.writeText(href).then(()=>setShareButton("Copied link")).catch(fallbackCopy); } else { fallbackCopy(); } function fallbackCopy(){ const ta=document.createElement('textarea'); ta.value=href; ta.setAttribute('readonly',''); ta.style.position='fixed'; ta.style.left='-9999px'; document.body.appendChild(ta); ta.select(); const ok=document.execCommand && document.execCommand('copy'); ta.remove(); setShareButton(ok?"Copied link":"Copy failed"); } }
+function openHelp(topic, trigger){ const item = HelpTopics[topic] || HelpTopics.overview; lastHelpTrigger = trigger || document.activeElement; document.getElementById('helpKicker').textContent = item.kicker; document.getElementById('helpTitle').textContent = item.title; document.getElementById('helpBody').innerHTML = item.body; document.getElementById('helpOverlay').hidden = false; document.getElementById('helpClose').focus(); }
+function closeHelp(){ document.getElementById('helpOverlay').hidden = true; if(lastHelpTrigger && typeof lastHelpTrigger.focus === "function") lastHelpTrigger.focus(); }
+function wireHelp(){ document.querySelectorAll('[data-help]').forEach(btn=>{ btn.addEventListener('click',()=>openHelp(btn.dataset.help, btn)); }); document.getElementById('helpClose').addEventListener('click', closeHelp); document.getElementById('helpOverlay').addEventListener('click', e=>{ if(e.target.id === 'helpOverlay') closeHelp(); }); document.addEventListener('keydown', e=>{ if(e.key === "Escape" && !document.getElementById('helpOverlay').hidden) closeHelp(); }); }
+window.addEventListener('DOMContentLoaded', ()=>{ setSeed(seed); restoreFromURL(); renderSteps(); updateAll(); wireHelp(); document.getElementById('resetBtn').onclick = resetAll; document.getElementById('seedBtn').onclick = ()=>{ setSeed(Math.floor(Math.random()*1e9)); updateAll(); }; document.getElementById('shareBtn').onclick = copyShareLink; });
+</script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a small, self-contained demo that links deterministic replay evidence, machine‑checkable rule receipts, and a provenance/lineage DAG to illustrate governance checks.
- Make it easy to experiment with workflow event combinations and observe how receipts and lineage update in real time for teaching and validation purposes.

### Description
- Added a new standalone web app at `web_apps/governance-trio-replay-rules-lineage.html` implementing the provided HTML/CSS/JS UI and logic for the demo.
- Implemented deterministic replay proof with a seed and local PRNG, an ordered event log (`run_id` + timestamps), and a URL share state encoded in the hash for reproducible runs.
- Implemented machine-checkable rule receipts (R1–R4) evaluating reviewers, traceability, timing, and approver authority, and a lineage DAG canvas that draws edges only for present artefacts.
- Registered the app in `app-index.csv` (new entry id `76`) so it appears in the project index.

### Testing
- Ran `npm test`; the run failed due to the repository test harness treating `test.js` as an ES module while it uses CommonJS `require`, causing a Node.js `ReferenceError` (existing repo issue), so no passing test suite output was produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f91297a0ac8332bdd715ad0ecca124)